### PR TITLE
Prevent code in "USAGE" chunk from evaluating when Rmd is knitr'ed

### DIFF
--- a/R/rmd_help.R
+++ b/R/rmd_help.R
@@ -59,7 +59,8 @@ rmd_help <- function(topic) {
     usage_end_line <- min(headings[headings > usage_line]) - 2
     rmd_help <- c(
       rmd_help[1:usage_line + 1],
-      "```{r}",
+      # Mark this usage chunk for non-evalualtion
+      "```{r eval=FALSE}",
       rmd_help[(usage_line + 2):usage_end_line],
       "```",
       rmd_help[(usage_end_line + 1):length(rmd_help)]


### PR DESCRIPTION
Thanks for this nice package. I always felt constrained by RStudio's help browser.

When I decided to knitr the generated Rmd file, I found that the "USAGE" chunk will usually cause an error, as it uses variables that do not exist.

So I added "eval=FALSE" to that chunk.